### PR TITLE
Configure MathJax library for TeX preview

### DIFF
--- a/ckeditor/config.js
+++ b/ckeditor/config.js
@@ -9,7 +9,8 @@ CKEDITOR.editorConfig = function( config ) {
 	// config.uiColor = '#AADC6E';
 	
 	
-	// config.mathJaxLib = 'https://www.wiris.net/demo/plugins/app/WIRISplugins.js?viewer=image';
+        // Path to the MathJax library that enables TeX preview and output
+        config.mathJaxLib = 'https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS_HTML';
 
 	 config.extraPlugins = 'mathjax,ckeditor_wiris';
 	   config.removePlugins = 'image,about,iframe,specialchar,emoticons,flash,smiley,pagebreak,preview,print,horizontalrule,stickies,blockselection,div,save,templates,showblocks,scayt,wsc,menubutton,contextmenu,find,selectall,copyformatting,removeformat';


### PR DESCRIPTION
## Summary
- point CKEditor mathjax plugin at CDN-hosted MathJax library to enable preview and insertion

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1132849483268c8e215c2c0940b0