### PR TITLE
Integrate MathType plugin into CKEditor example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # ckeditor4-with-mathjax
-# ckeditor4-with-mathjax
+
+Demo project showing CKEditor 4 integrated with MathJax and the WIRIS (MathType) plugin.
+
+## Usage
+
+1. Open `index.html` in a browser.
+2. Use the MathType buttons in the toolbar to insert math and chemistry formulas.

--- a/ckeditor/config.js
+++ b/ckeditor/config.js
@@ -12,13 +12,14 @@ CKEDITOR.editorConfig = function( config ) {
         // Path to the MathJax library that enables TeX preview and output
         config.mathJaxLib = 'https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS_HTML';
 
-	 config.extraPlugins = 'mathjax,ckeditor_wiris';
-	   config.removePlugins = 'image,about,iframe,specialchar,emoticons,flash,smiley,pagebreak,preview,print,horizontalrule,stickies,blockselection,div,save,templates,showblocks,scayt,wsc,menubutton,contextmenu,find,selectall,copyformatting,removeformat';
-	 config.toolbarGroups = [
-		{ name: 'basicstyles', groups: [ 'Bold', 'Italic', 'Subscript', 'Superscript' ] },
-		{ name: 'insert',      groups: [ 'insert' ] },
-		{ name: 'tools',      groups: [ 'tools' ] },
-	];
-	
-	 
+        // Load MathJax and the WIRIS (MathType) plugin
+        config.extraPlugins = 'mathjax,ckeditor_wiris';
+        config.removePlugins = 'image,about,iframe,specialchar,emoticons,flash,smiley,pagebreak,preview,print,horizontalrule,stickies,blockselection,div,save,templates,showblocks,scayt,wsc,menubutton,contextmenu,find,selectall,copyformatting,removeformat';
+
+        // Expose MathType buttons in the toolbar
+        config.toolbar = [
+                { name: 'clipboard', items: [ 'Cut', 'Copy', 'Paste', '-', 'Undo', 'Redo' ] },
+                { name: 'basicstyles', items: [ 'Bold', 'Italic', 'Subscript', 'Superscript' ] },
+                { name: 'wiris', items: [ 'ckeditor_wiris_formulaEditor', 'ckeditor_wiris_formulaEditorChemistry' ] }
+        ];
 };

--- a/index.html
+++ b/index.html
@@ -3,13 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CkEditor</title>
+    <title>CKEditor with MathType</title>
     <script src="ckeditor/ckeditor.js"></script>
-     <script type="text/javascript" src="wiriscripts.js"></script>
+    <script src="wiriscripts.js"></script>
 </head>
 <body>
-    <div>
-        <textarea cols="30" rows="10" name="content" id="content" class="ckeditor"></textarea>
-    </div>
+    <textarea id="editor"></textarea>
+    <script>
+        CKEDITOR.replace('editor');
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- configure CKEditor to expose MathType buttons and load ckeditor_wiris
- simplify example page and initialize editor in script
- document how to use the demo

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc146af76883268b9baa54f314ea15