### PR TITLE
Fix MathType button by loading WIRIS integration from CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ Demo project showing CKEditor 4 integrated with MathJax and the WIRIS (MathType)
 
 ## Usage
 
-1. Open `index.html` in a browser.
+1. Open `index.html` in a browser (an internet connection is required to load the MathType integration script).
 2. Use the MathType buttons in the toolbar to insert math and chemistry formulas.

--- a/index.html
+++ b/index.html
@@ -5,7 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CKEditor with MathType</title>
     <script src="ckeditor/ckeditor.js"></script>
-    <script src="wiriscripts.js"></script>
+    <!-- Load MathType integration script from the official CDN -->
+    <script src="https://www.wiris.net/demo/plugins/app/WIRISplugins.js?viewer=image"></script>
 </head>
 <body>
     <textarea id="editor"></textarea>


### PR DESCRIPTION
## Summary
- Load MathType integration script from official WIRIS CDN so formula editor button works
- Note internet requirement in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc19c6e0f883269a57fc741074ee87