### PR TITLE
Enable MathType button in CKEditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ Demo project showing CKEditor 4 integrated with MathJax and the WIRIS (MathType)
 
 1. Open `index.html` in a browser (an internet connection is required to load the MathType integration script).
 2. Use the MathType buttons in the toolbar to insert math and chemistry formulas.
+
+The editor loads the WIRIS plugin by specifying `extraPlugins: 'ckeditor_wiris'` and adds the `MathType` and `ChemType` buttons to the toolbar.

--- a/index.html
+++ b/index.html
@@ -11,7 +11,12 @@
 <body>
     <textarea id="editor"></textarea>
     <script>
-        CKEDITOR.replace('editor');
+        CKEDITOR.replace('editor', {
+            extraPlugins: 'ckeditor_wiris',
+            toolbar: [
+                ['Bold', 'Italic', 'MathType', 'ChemType']
+            ]
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- configure CKEditor to load the WIRIS plugin and expose MathType buttons
- document MathType plugin configuration in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1b2061e48326a515c904e78c390a