### PR TITLE
Enable MathJax plugin in demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ckeditor4-with-mathjax
 
-Demo project showing CKEditor 4 integrated with MathJax and the WIRIS (MathType) plugin.
+Demo project showing CKEditor 4 integrated with the MathJax and WIRIS (MathType) plugins.
 
 ## Usage
 
-1. Open `index.html` in a browser (an internet connection is required to load the MathType integration script).
-2. Use the MathType buttons in the toolbar to insert math and chemistry formulas.
+1. Open `index.html` in a browser (an internet connection is required to load the external scripts).
+2. Use the Mathjax button to insert TeX equations and the MathType buttons to insert math and chemistry formulas.
 
-The editor loads the WIRIS plugin by specifying `extraPlugins: 'ckeditor_wiris'` and adds the `MathType` and `ChemType` buttons to the toolbar.
+The editor loads the MathJax and WIRIS plugins by specifying `extraPlugins: 'mathjax,ckeditor_wiris'` and adds the `Mathjax`, `MathType` and `ChemType` buttons to the toolbar. The MathJax library is loaded from the CDN configured via the `mathJaxLib` option.

--- a/index.html
+++ b/index.html
@@ -3,8 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CKEditor with MathType</title>
+    <title>CKEditor with MathJax and MathType</title>
     <script src="ckeditor/ckeditor.js"></script>
+    <!-- The MathJax plugin loads the MathJax library from the URL specified in the configuration. -->
     <!-- Load MathType integration script from the official CDN -->
     <script src="https://www.wiris.net/demo/plugins/app/WIRISplugins.js?viewer=image"></script>
 </head>
@@ -12,9 +13,10 @@
     <textarea id="editor"></textarea>
     <script>
         CKEDITOR.replace('editor', {
-            extraPlugins: 'ckeditor_wiris',
+            extraPlugins: 'mathjax,ckeditor_wiris',
+            mathJaxLib: 'https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS_HTML',
             toolbar: [
-                ['Bold', 'Italic', 'MathType', 'ChemType']
+                ['Bold', 'Italic', 'Mathjax', 'MathType', 'ChemType']
             ]
         });
     </script>


### PR DESCRIPTION
## Summary
- load MathJax plugin alongside MathType to display MathJax toolbar icon
- document MathJax configuration and combined toolbar usage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc22368000832686852109561bf07d