### PR TITLE
Fix MathType toolbar configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Demo project showing CKEditor 4 integrated with the MathJax and WIRIS (MathType)
 ## Usage
 
 1. Open `index.html` in a browser (an internet connection is required to load the external scripts).
-2. Use the Mathjax button to insert TeX equations and the MathType buttons to insert math and chemistry formulas.
+2. Use the MathJax button to insert TeX equations and the MathType buttons to insert math and chemistry formulas.
 
-The editor loads the MathJax and WIRIS plugins by specifying `extraPlugins: 'mathjax,ckeditor_wiris'` and adds the `Mathjax`, `MathType` and `ChemType` buttons to the toolbar. The MathJax library is loaded from the CDN configured via the `mathJaxLib` option.
+The editor loads the MathJax and WIRIS plugins by specifying `extraPlugins: 'mathjax,ckeditor_wiris'`, allows MathML content with `allowedContent: true`, and adds the `Mathjax`, `ckeditor_wiris_formulaEditor` and `ckeditor_wiris_formulaEditorChemistry` buttons to the toolbar. The MathJax library is loaded from the CDN configured via the `mathJaxLib` option.

--- a/index.html
+++ b/index.html
@@ -15,8 +15,10 @@
         CKEDITOR.replace('editor', {
             extraPlugins: 'mathjax,ckeditor_wiris',
             mathJaxLib: 'https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS_HTML',
+            // Allow MathML content required by MathType plugin.
+            allowedContent: true,
             toolbar: [
-                ['Bold', 'Italic', 'Mathjax', 'MathType', 'ChemType']
+                ['Bold', 'Italic', 'Mathjax', 'ckeditor_wiris_formulaEditor', 'ckeditor_wiris_formulaEditorChemistry']
             ]
         });
     </script>


### PR DESCRIPTION
## Summary
- enable MathType by adding allowed MathML content and proper toolbar button names

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc337300dc832682f5997f083043f1