### PR TITLE
Load MathType plugin locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Demo project showing CKEditor 4 integrated with the MathJax and WIRIS (MathType)
 
 ## Usage
 
-1. Open `index.html` in a browser (an internet connection is required to load the external scripts).
+1. Open `index.html` in a browser. The MathType integration script is bundled locally, but an internet connection is still required to load the MathJax library from the CDN.
 2. Use the MathJax button to insert TeX equations and the MathType buttons to insert math and chemistry formulas.
 
 The editor loads the MathJax and WIRIS plugins by specifying `extraPlugins: 'mathjax,ckeditor_wiris'`, allows MathML content with `allowedContent: true`, and adds the `Mathjax`, `ckeditor_wiris_formulaEditor` and `ckeditor_wiris_formulaEditorChemistry` buttons to the toolbar. The MathJax library is loaded from the CDN configured via the `mathJaxLib` option.

--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
     <title>CKEditor with MathJax and MathType</title>
     <script src="ckeditor/ckeditor.js"></script>
     <!-- The MathJax plugin loads the MathJax library from the URL specified in the configuration. -->
-    <!-- Load MathType integration script from the official CDN -->
-    <script src="https://www.wiris.net/demo/plugins/app/WIRISplugins.js?viewer=image"></script>
+    <!-- Load MathType integration script locally to avoid CDN dependency -->
+    <script src="wiriscripts.js"></script>
 </head>
 <body>
     <textarea id="editor"></textarea>


### PR DESCRIPTION
## Summary
- Serve MathType integration script from a local file to avoid CDN dependency
- Update README to explain MathType script is bundled locally while MathJax still loads from a CDN

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3703e4a48326b8978023945ed974